### PR TITLE
Fix usage of print

### DIFF
--- a/proj.py
+++ b/proj.py
@@ -16,7 +16,7 @@ def main():
         else:
             node0, node1, dist, maxSpd = map(str, line.split())
 
-        print(node0 + ' ' + node1 + ' ' + dist + ' ' + maxSpd)
+        print(node0, node1, dist, maxSpd)
         # splitted = list(map(str, line.split()))
         # node0 = splitted[0]
         # node1 = splitted[1]


### PR DESCRIPTION
Invoking `print` with multiple arguments separates them with a space, no need for string concatenation (which is O(n²))

```python
>>> help(print)
    print(value, ..., sep=' ', end='\n', file=sys.stdout, flush=False)
    ...
    sep:   string inserted between values, default a space.
```